### PR TITLE
Fix issue with non-host leaving meetings

### DIFF
--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -957,7 +957,6 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   // InMeetingServiceListener required listeners
   @Override
   public void onMeetingLeaveComplete(long ret) {
-    updateVideoView();
     sendEvent("MeetingEvent", getMeetingEndReasonName((int)ret));
   }
 


### PR DESCRIPTION
updateVideoView was causing issues when leaving meetings. Removing it resolves them.